### PR TITLE
Add describe method for primitives

### DIFF
--- a/sda/sda_file.py
+++ b/sda/sda_file.py
@@ -113,8 +113,8 @@ class SDAFile(object):
         return self._get_attr('Created')
 
     @property
-    def Modified(self):
-        return self._get_attr('Modified')
+    def Updated(self):
+        return self._get_attr('Updated')
 
     # Public
     def insert(self, label, data, description='', deflate=0):
@@ -177,7 +177,7 @@ class SDAFile(object):
             msg = "Unrecognized record type '{}'".format(record_type)
             raise RuntimeError(msg)
 
-        self._update_modified()
+        self._update_timestamp()
 
     # Private
     def _insert_data(self, label, data, description, deflate, record_type):
@@ -246,6 +246,6 @@ class SDAFile(object):
         with self._h5file('r') as h5file:
             return h5file.attrs[attr]
 
-    def _update_modified(self):
+    def _update_timestamp(self):
         with self._h5file('a') as h5file:
-            h5file.attrs['Modified'] = get_date_str()
+            h5file.attrs['Updated'] = get_date_str()

--- a/sda/testing.py
+++ b/sda/testing.py
@@ -12,7 +12,7 @@ BAD_ATTRS = {
     'FormatVersion': '0.5',
     'Writable': 'nope',
     'Created': '2017-01-01 01:23:45',
-    'Modified': '2017-01-01 01:23:45',
+    'Updated': '2017-01-01 01:23:45',
 }
 
 
@@ -21,7 +21,7 @@ GOOD_ATTRS = {
     'FormatVersion': '1.1',
     'Writable': 'yes',
     'Created': '18-Aug-2017 01:23:45',
-    'Modified': '18-Aug-2017 01:23:45',
+    'Updated': '18-Aug-2017 01:23:45',
 }
 
 

--- a/sda/tests/test_sda_file.py
+++ b/sda/tests/test_sda_file.py
@@ -158,13 +158,20 @@ class TestSDAFileInsert(unittest.TestCase):
             with self.assertRaises(ValueError):
                 sda_file.insert('test', [1, 2, 3])
 
-    def test_character_scalar(self):
-        values = (obj for (obj, typ) in TEST_SCALARS if typ == 'character')
+    def test_timestamp_update(self):
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
                 h5file.attrs['Updated'] = 'Unmodified'
 
+            sda_file.insert('test', [0, 1, 2])
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
+
+    def test_character_scalar(self):
+        values = (obj for (obj, typ) in TEST_SCALARS if typ == 'character')
+
+        with temporary_file() as file_path:
+            sda_file = SDAFile(file_path, 'w')
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
                 deflate = i % 10
@@ -173,9 +180,6 @@ class TestSDAFileInsert(unittest.TestCase):
                 self.assertRecord(
                     sda_file, 'character', label, deflate, 'no', expected
                 )
-
-            # Make sure the 'Updated' attr gets updated
-            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
             label = 'test_empty'
             deflate = 0
@@ -188,8 +192,6 @@ class TestSDAFileInsert(unittest.TestCase):
         values = (obj for (obj, typ) in TEST_ARRAYS if typ == 'logical')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
-            with sda_file._h5file('a') as h5file:
-                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -200,15 +202,10 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'logical', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Updated' attr gets updated
-            self.assertNotEqual(sda_file.Updated, 'Unmodified')
-
     def test_logical_scalar(self):
         values = (obj for (obj, typ) in TEST_SCALARS if typ == 'logical')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
-            with sda_file._h5file('a') as h5file:
-                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -219,15 +216,10 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'logical', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Updated' attr gets updated
-            self.assertNotEqual(sda_file.Updated, 'Unmodified')
-
     def test_numeric_array(self):
         values = (obj for (obj, typ) in TEST_ARRAYS if typ == 'numeric')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
-            with sda_file._h5file('a') as h5file:
-                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -238,9 +230,6 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'numeric', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Updated' attr gets updated
-            self.assertNotEqual(sda_file.Updated, 'Unmodified')
-
             label = 'test_empty'
             deflate = 0
             sda_file.insert(label, [], label, deflate)
@@ -250,8 +239,6 @@ class TestSDAFileInsert(unittest.TestCase):
         values = (obj for (obj, typ) in TEST_SCALARS if typ == 'numeric')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
-            with sda_file._h5file('a') as h5file:
-                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -260,9 +247,6 @@ class TestSDAFileInsert(unittest.TestCase):
                 self.assertRecord(
                     sda_file, 'numeric', label, deflate, 'no', obj
                 )
-
-            # Make sure the 'Updated' attr gets updated
-            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
             label = 'test_nan'
             deflate = 0
@@ -338,6 +322,7 @@ class TestSDAFileDescribe(unittest.TestCase):
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
                 h5file.attrs['Updated'] = 'Unmodifed'
+
             sda_file.insert('test', [1, 2, 3])
             sda_file.describe('test', 'second')
             with sda_file._h5file('r') as h5file:

--- a/sda/tests/test_sda_file.py
+++ b/sda/tests/test_sda_file.py
@@ -69,11 +69,11 @@ class TestSDAFileInit(unittest.TestCase):
 
         """
         if attrs == {}:  # treat as if new
-            self.assertEqual(sda_file.Created, sda_file.Modified)
+            self.assertEqual(sda_file.Created, sda_file.Updated)
             attrs = {}
             write_header(attrs)
             del attrs['Created']
-            del attrs['Modified']
+            del attrs['Updated']
 
         for attr, expected in attrs.items():
             actual = getattr(sda_file, attr)
@@ -163,7 +163,7 @@ class TestSDAFileInsert(unittest.TestCase):
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -174,8 +174,8 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'character', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Modified' attr gets updated
-            self.assertNotEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr gets updated
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
             label = 'test_empty'
             deflate = 0
@@ -189,7 +189,7 @@ class TestSDAFileInsert(unittest.TestCase):
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -200,15 +200,15 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'logical', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Modified' attr gets updated
-            self.assertNotEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr gets updated
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
     def test_logical_scalar(self):
         values = (obj for (obj, typ) in TEST_SCALARS if typ == 'logical')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -219,15 +219,15 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'logical', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Modified' attr gets updated
-            self.assertNotEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr gets updated
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
     def test_numeric_array(self):
         values = (obj for (obj, typ) in TEST_ARRAYS if typ == 'numeric')
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -238,8 +238,8 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'numeric', label, deflate, 'no', expected
                 )
 
-            # Make sure the 'Modified' attr gets updated
-            self.assertNotEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr gets updated
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
             label = 'test_empty'
             deflate = 0
@@ -251,7 +251,7 @@ class TestSDAFileInsert(unittest.TestCase):
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(values):
                 label = 'test' + str(i)
@@ -261,8 +261,8 @@ class TestSDAFileInsert(unittest.TestCase):
                     sda_file, 'numeric', label, deflate, 'no', obj
                 )
 
-            # Make sure the 'Modified' attr gets updated
-            self.assertNotEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr gets updated
+            self.assertNotEqual(sda_file.Updated, 'Unmodified')
 
             label = 'test_nan'
             deflate = 0
@@ -273,15 +273,15 @@ class TestSDAFileInsert(unittest.TestCase):
         with temporary_file() as file_path:
             sda_file = SDAFile(file_path, 'w')
             with sda_file._h5file('a') as h5file:
-                h5file.attrs['Modified'] = 'Unmodified'
+                h5file.attrs['Updated'] = 'Unmodified'
 
             for i, obj in enumerate(TEST_UNSUPPORTED):
                 label = 'test' + str(i)
                 with self.assertRaises(ValueError):
                     sda_file.insert(label, obj, label, 0)
 
-            # Make sure the 'Modified' attr does not get updated
-            self.assertEqual(sda_file.Modified, 'Unmodified')
+            # Make sure the 'Updated' attr does not get updated
+            self.assertEqual(sda_file.Updated, 'Unmodified')
 
     def assertRecord(self, sda_file, record_type, label, deflate, empty,
                      expected):

--- a/sda/tests/test_utils.py
+++ b/sda/tests/test_utils.py
@@ -108,7 +108,7 @@ class TestUtils(unittest.TestCase):
             self.assertEqual(attrs['FileFormat'], 'SDA')
             self.assertEqual(attrs['FormatVersion'], '1.0')
             self.assertEqual(attrs['Writable'], 'yes')
-            self.assertEqual(attrs['Created'], attrs['Modified'])
+            self.assertEqual(attrs['Created'], attrs['Updated'])
 
     def test_infer_record_type(self):
 

--- a/sda/utils.py
+++ b/sda/utils.py
@@ -47,8 +47,8 @@ def error_if_bad_header(h5file):
     # Created flag
     error_if_bad_attr(h5file, 'Created', is_valid_date)
 
-    # Modified flag
-    error_if_bad_attr(h5file, 'Modified', is_valid_date)
+    # Updated flag
+    error_if_bad_attr(h5file, 'Updated', is_valid_date)
 
 
 def error_if_not_writable(h5file):
@@ -145,4 +145,4 @@ def write_header(attrs):
     attrs['Writable'] = 'yes'
     date_str = get_date_str()
     attrs['Created'] = date_str
-    attrs['Modified'] = date_str
+    attrs['Updated'] = date_str


### PR DESCRIPTION
The name `describe` makes me think of `pandas.DataFrame.describe`, but it does not act like it. I'm choosing to stick close to the conventions known by the SMASH user base. I'm finding these in the [SMASHtoolbox](https://github.com/SMASHtoolbox/release) repo. 